### PR TITLE
Update hbs requirement in package.json for test app

### DIFF
--- a/test/app/package.json
+++ b/test/app/package.json
@@ -4,7 +4,7 @@
   "description": "Test app for istanbul middleware",
   "dependencies": {
       "express": "3.x",
-      "hbs": "*",
+      "hbs": ">=1.0.2",
       "istanbul-middleware": "*",
       "nopt": "*"
   }


### PR DESCRIPTION
HBS >= 1.0.2 added support for express 3.0 templates. Anything less and you'll get some weird messages.
https://github.com/donpark/hbs/blob/v1.0.2/lib/hbs.js
vs https://github.com/donpark/hbs/blob/1.0.1/lib/hbs.js
