### PR TITLE
Increased the accepted max file size, replaced obsolete call

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -23,8 +23,9 @@ function createHandler(opts) {
 
     var app = express();
 
-    app.use(express.json());
-    app.use(express.urlencoded());
+    // set 100mb as the default max size limit for coverage reports
+    app.use(express.json({ limit: '100mb' }));
+    app.use(express.urlencoded({ limit: '100mb' }));
 
     //show main page for coverage report for /
     app.get('/', function (req, res) {


### PR DESCRIPTION
Middleware did not accept larger coverage json files than 1mb, which was not enough for us.

I did not find any reason for not increasing it.
I set the limit to 100mb and also replaced the soon-to-be obsolete call bodyParser() with the json() and urlencoded().
