### PR TITLE
Connect will deprecate some methods in connect 3.0 #8

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -22,8 +22,8 @@ function createHandler(opts) {
     opts = opts || {};
 
     var app = express();
-    app.use(express.urlencoded())
-    app.use(express.json())
+    app.use(express.urlencoded());
+    app.use(express.json());
 
     //show main page for coverage report for /
     app.get('/', function (req, res) {


### PR DESCRIPTION
upstream Connect.bodyParser() will be deprecated in 3.0, the Express facade will be deprecated as well
