### PR TITLE
Add validations if client posts incorrect coverage JSON to the middleware

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -226,6 +226,11 @@ function mergeClientCoverage(obj) {
         } else {
             result = added;
         }
+
+        if (!result.b) {
+            result.b = [];
+        }
+
         coverage[filePath] = result;
     });
 }


### PR DESCRIPTION
Hi, I got error when collecting client-side coverage.

The error happened because some files did not have any branches.
So here I fix the case when __coverage__ entry has no **b** property because **Object.keys** fails on _undefined_.

See error trace:

```
TypeError: Object.keys called on non-object
   at Function.keys (native)
   at computeBranchTotals (/Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/node_modules/istanbul/lib/object-utils.js:127:16)
   at Object.summarizeFileCoverage (/Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/node_modules/istanbul/lib/object-utils.js:214:24)
   at /Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/lib/core.js:132:54
   at Array.forEach (native)
   at getTreeSummary (/Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/lib/core.js:131:23)
   at Object.render (/Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/lib/core.js:173:19)
   at /Users/noomorph/Projects/myproject/node_modules/istanbul-middleware/lib/handlers.js:47:14
   at Layer.handle [as handle_request] (/Users/noomorph/Projects/myproject/node_modules/express/lib/router/layer.js:76:5)
   at next (/Users/noomorph/Projects/myproject/node_modules/express/lib/router/route.js:100:13)
```
