### PR TITLE
Update body-parser to fix requiresafe check

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dependencies":{
         "istanbul":"0.2.x",
         "express":"4.x",
-        "body-parser": "~1.4.3",
+        "body-parser": "1.12.x",
         "archiver": "0.10.x"
     },
     "devDependencies":{


### PR DESCRIPTION
Update body-parser to the latest to fix "requiresafe check".  While I understand istanbul should never really be a security issue, as it should never be running in production, I need to fix this up to get a green requiresafe check build that is part of our automated process.

Updates for body-parse are shown at https://github.com/expressjs/body-parser/blob/master/HISTORY.md