### PR TITLE
add vendors directory to assets gathering

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -8,6 +8,7 @@ var path = require('path'),
     istanbul = require('istanbul'),
     bodyParser = require('body-parser'),
     ASSETS_DIR = istanbul.assetsDir,
+    VENDORS_DIR = path.resolve(ASSETS_DIR+"/vendor/"),
     existsSync = fs.existsSync || path.existsSync,
     url = require('url'),
     archiver = require('archiver'),
@@ -65,7 +66,13 @@ function createHandler(opts) {
 
     //send static file for /asset/asset-name
     app.get('/asset/:name', function (req, res) {
-        res.sendfile(path.resolve(ASSETS_DIR, req.params.name));
+        var pathInAssets = path.resolve(ASSETS_DIR, req.params.name);
+        if(existsSync(pathInAssets)) {
+            res.sendfile(pathInAssets);
+        } else {
+            var pathInVendors = path.resolve(VENDORS_DIR, req.params.name);
+            res.sendfile(pathInVendors);
+        }
     });
 
     //reset coverage to baseline on POST /reset


### PR DESCRIPTION
When calling <host>/coverage there are some assets that cannot be found because in istanbul they are in /lib/assets/vendor and not in asset directory.
Just add a check to inport them from vendor directory if they are not in asset directory.

As long as asset dir is not correct in istanbul it wont completelly work, see pull request there
https://github.com/gotwarlost/istanbul/pull/467
