### PR TITLE
add a header to ensure chrome44+ will display all fillbar correctly

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -203,6 +203,7 @@ function render(filePath, res, prefix) {
 
     report = Report.create('html', { linkMapper: linkMapper });
     res.setHeader('Content-type', 'text/html');
+    res.setHeader('Content-Security-Policy', "allow 'self'; 'unsafe-inline';");
     if (outputNode.kind === 'dir') {
         report.writeIndexPage(res, outputNode);
     } else {


### PR DESCRIPTION
chrome44+ and latest chromium builds add a security check to inline scripting that prevent in that project to display all fillbars with a warning in the console when using the route "/coverage".

I add a header Content-Security-Policy to allow unsafe-inline, seems to solve that problem and all fillbars are now correctly displayed.

the bug seems not to appear on downloaded html report, only online reports (localhost:XXX/coverage"