### PR TITLE
Fix location of istanbul assets for builtin server

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -65,7 +65,18 @@ function createHandler(opts) {
 
     //send static file for /asset/asset-name
     app.get('/asset/:name', function (req, res) {
-        res.sendfile(path.resolve(ASSETS_DIR, req.params.name));
+        // ASSETS_DIR is lying.  It points to
+        // .../node_modules/istanbul/lib/vendor, which doesn't exist.
+        // We should be looking in .../node_modules/istanbul/lib/assets
+        // and .../node_modules/istanbul/lib/assets/vendor
+        if (existsSync (path.resolve (ASSETS_DIR, '..', 'assets',
+                                      req.params.name))) {
+            res.sendfile(path.resolve(ASSETS_DIR, '..', 'assets',
+                                      req.params.name));
+        } else {
+            res.sendfile(path.resolve(ASSETS_DIR, '..', 'assets', 'vendor',
+                                      req.params.name));
+        }
     });
 
     //reset coverage to baseline on POST /reset


### PR DESCRIPTION
The live coverage report was missing the istanbul CSS and .js files, as istanbul is telling it the wrong location to find them.  Even if istanbul fixes the location, we still need to look in a subdirectory as well.

This patch takes the reported assetsDir, and locates the assets relative to it.
