### PR TITLE
enable istanbul-middleware getInstrumentor()

### DIFF
--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -192,7 +192,8 @@ function createClientHandler(root, opts) {
 module.exports = {
     createClientHandler: createClientHandler,
     createHandler: createHandler,
-    hookLoader: core.hookLoader
+    hookLoader: core.hookLoader,
+    getInstrumenter: core.getInstrumenter
 };
 
 


### PR DESCRIPTION
the getInstrumenter should be exported in handlers.js to use istanbul-middleware.getInstrumentor()
