### PR TITLE
add a way to download custom format reports

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -100,7 +100,7 @@ function hookLoader(matcherOrRoot, opts) {
 
     postLoadHook = opts.postLoadHook;
     if (!(postLoadHook && typeof postLoadHook === 'function')) {
-        postLoadHook = function (/* matcher, transformer, verbose */) { return function (/* file */) {}; };
+        postLoadHook = function (/* matcher, transformer, verbose */) { return function (/* file */) { }; };
     }
     delete opts.postLoadHook;
 
@@ -223,7 +223,11 @@ function mergeClientCoverage(obj) {
             added = obj[filePath],
             result;
         if (original) {
-            result = utils.mergeFileCoverage(original, added);
+            try {
+                result = utils.mergeFileCoverage(original, added);
+            } catch (e) {
+                result = original;
+            }
         } else {
             result = added;
         }

--- a/lib/core.js
+++ b/lib/core.js
@@ -203,6 +203,7 @@ function render(filePath, res, prefix) {
 
     report = Report.create('html', { linkMapper: linkMapper });
     res.setHeader('Content-type', 'text/html');
+    res.setHeader('Content-Security-Policy', "allow 'self'; 'unsafe-inline';");
     if (outputNode.kind === 'dir') {
         report.writeIndexPage(res, outputNode);
     } else {

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -6,6 +6,7 @@ var path = require('path'),
     fs = require('fs'),
     core = require('./core'),
     istanbul = require('istanbul'),
+    FileWriter = istanbul.FileWriter,
     bodyParser = require('body-parser'),
     ASSETS_DIR = istanbul.assetsDir,
     existsSync = fs.existsSync || path.existsSync,
@@ -112,6 +113,51 @@ function createHandler(opts) {
             report.writeReport(collector);
         });
         writer.done();
+    });
+
+    app.get('/downloadFormat', function (req, res) {
+        var
+          availlableFormat = ['json', 'cobertura', 'clover', 'json-summary', 'lcovonly'],
+          writer = new FileWriter({sync: true}),
+          coverageObject = core.getCoverageObject() || {},
+          collector = new Collector(),
+          baseDir = opts.tmpDir || process.cwd(),
+          format = req.query.format || 'json',
+          file,
+          report;
+        if(availlableFormat.indexOf(format) === -1){
+            res.statusCode = '403';
+            return res.send();
+        }
+        report = Report.create(format,
+          {
+              writer: writer,
+              dir: baseDir
+          });
+
+        utils.removeDerivedInfo(coverageObject);
+        collector.add(coverageObject);
+
+        res.statusCode = 200;
+        res.setHeader('Content-type', 'application/octet-stream');
+        report.writeReport(collector);
+
+        if(report.file){
+            file = report.file;
+        } else if (report.opts && report.opts.file){
+            file = report.opts.file;
+        }
+        if(!file){
+            res.statusCode = '403';
+            return res.send();
+        }
+        var filePath = path.join(baseDir, file);
+        var stat = fs.statSync(filePath);
+        res.setHeader('Content-Disposition', 'attachment; filename='+file);
+        res.setHeader('Content-Length', stat.size);
+        fs.createReadStream(filePath).pipe(res).on('finish', function(){
+            fs.unlink(filePath);
+        });
     });
 
     //merge client coverage posted from browser

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -110,30 +110,34 @@ function createHandler(opts) {
             w.write(JSON.stringify(coverageObject, undefined, 4));
         });
         reports.forEach(function (report) {
-            report.writeReport(collector);
+            try {
+                report.writeReport(collector);
+            } catch (e) {
+                console.error(e);
+            }
         });
         writer.done();
     });
 
     app.get('/downloadFormat', function (req, res) {
         var
-          availlableFormat = ['json', 'cobertura', 'clover', 'json-summary', 'lcovonly'],
-          writer = new FileWriter({sync: true}),
-          coverageObject = core.getCoverageObject() || {},
-          collector = new Collector(),
-          baseDir = opts.tmpDir || process.cwd(),
-          format = req.query.format || 'json',
-          file,
-          report;
-        if(availlableFormat.indexOf(format) === -1){
+            availlableFormat = ['json', 'cobertura', 'clover', 'json-summary', 'lcovonly'],
+            writer = new FileWriter({ sync: true }),
+            coverageObject = core.getCoverageObject() || {},
+            collector = new Collector(),
+            baseDir = opts.tmpDir || process.cwd(),
+            format = req.query.format || 'json',
+            file,
+            report;
+        if (availlableFormat.indexOf(format) === -1) {
             res.statusCode = '403';
             return res.send();
         }
         report = Report.create(format,
-          {
-              writer: writer,
-              dir: baseDir
-          });
+            {
+                writer: writer,
+                dir: baseDir
+            });
 
         utils.removeDerivedInfo(coverageObject);
         collector.add(coverageObject);
@@ -142,20 +146,20 @@ function createHandler(opts) {
         res.setHeader('Content-type', 'application/octet-stream');
         report.writeReport(collector);
 
-        if(report.file){
+        if (report.file) {
             file = report.file;
-        } else if (report.opts && report.opts.file){
+        } else if (report.opts && report.opts.file) {
             file = report.opts.file;
         }
-        if(!file){
+        if (!file) {
             res.statusCode = '403';
             return res.send();
         }
         var filePath = path.join(baseDir, file);
         var stat = fs.statSync(filePath);
-        res.setHeader('Content-Disposition', 'attachment; filename='+file);
+        res.setHeader('Content-Disposition', 'attachment; filename=' + file);
         res.setHeader('Content-Length', stat.size);
-        fs.createReadStream(filePath).pipe(res).on('finish', function(){
+        fs.createReadStream(filePath).pipe(res).on('finish', function () {
             fs.unlink(filePath);
         });
     });
@@ -167,7 +171,7 @@ function createHandler(opts) {
             return res.send(400, 'Please post an object with content-type: application/json');
         }
         core.mergeClientCoverage(body);
-        res.json({ok: true});
+        res.json({ ok: true });
     });
 
     return app;


### PR DESCRIPTION
only made for single file formats: 'json', 'cobertura', 'clover', 'json-summary', 'lcovonly'
