### PR TITLE
Using SVG badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 istanbul-middleware
 ===================
 
-[![Build Status](https://travis-ci.org/gotwarlost/istanbul-middleware.png?branch=master)](https://travis-ci.org/gotwarlost/istanbul-middleware) [![Dependency Status](https://gemnasium.com/gotwarlost/istanbul-middleware.png)](https://gemnasium.com/gotwarlost/istanbul-middleware)
+[![Build Status](https://travis-ci.org/gotwarlost/istanbul-middleware.svg?branch=master)](https://travis-ci.org/gotwarlost/istanbul-middleware) [![Dependency Status](https://gemnasium.com/gotwarlost/istanbul-middleware.svg)](https://gemnasium.com/gotwarlost/istanbul-middleware)
 
 Connect middleware for getting code coverage numbers in functional tests for nodejs apps using istanbul.
 


### PR DESCRIPTION
SVG badge consume less bandwith and display better on MacBook Retina display.