### PR TITLE
add support for fmt query string parameter to /download endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ The above snippet adds the following endpoints to your app under `/coverage`
         <td>Download a zip file with coverage JSON, HTML and lcov reports</td>
     </tr>
     <tr>
+        <td><code>GET&nbsp;/download?fmt=json</code></td>
+        <td>Download the raw coverage JSON</td>
+    </tr>
+    <tr>
+    <tr>
         <td><code>POST&nbsp;/client</code></td>
         <td>
             Allows you to post a coverage object for client-side code coverage from the browser.
@@ -197,4 +202,3 @@ The following third-party libraries are used by this module:
 
 * express: https://github.com/visionmedia/express -  to implement the middleware
 * archiver: https://github.com/ctalkington/node-archiver - for zip functionality
-

--- a/lib/handlers.js
+++ b/lib/handlers.js
@@ -45,10 +45,19 @@ function createHandler(opts) {
     app.get('/', function (req, res) {
         var origUrl = url.parse(req.originalUrl).pathname,
             origLength = origUrl.length;
-        if (origUrl.charAt(origLength - 1) !== '/') {
-            origUrl += '/';
+        if (req.query.fmt) {
+          if (req.query.fmt === 'json' ) {
+            res.json(core.getCoverageObject() || {});
+          } else {
+            res.status(450)
+              .send('invalid format');
+          }
+        } else {
+          if (origUrl.charAt(origLength - 1) !== '/') {
+              origUrl += '/';
+          }
+          core.render(null, res, origUrl);
         }
-        core.render(null, res, origUrl);
     });
 
     //show page for specific file/ dir for /show?file=/path/to/file
@@ -194,5 +203,3 @@ module.exports = {
     createHandler: createHandler,
     hookLoader: core.hookLoader
 };
-
-

--- a/package.json
+++ b/package.json
@@ -27,10 +27,11 @@
     "archiver": "0.14.x"
   },
   "devDependencies": {
-    "mkdirp": "*",
-    "rimraf": "*",
-    "jshint": "*",
     "async": "*",
+    "jshint": "*",
+    "mkdirp": "*",
+    "request": "^2.81.0",
+    "rimraf": "*",
     "yui-lint": "*"
   },
   "engines": {

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -24,7 +24,7 @@ function setup(cb) {
         mkdirp.sync(outputDir);
         timeoutHandle = setTimeout(function () {
             throw new Error('Tests timed out');
-        }, 30000*2*2);
+        }, 30000);
         cb();
     } catch (ex) {
         cb(ex);


### PR DESCRIPTION
I added support to the /download endpoint for a 'fmt' query string parameter so the raw coverage can be downloaded in JSON format